### PR TITLE
Fixed a port number typo in doc/README.md

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -52,7 +52,7 @@ To run the development server:
 
     src/manage.py runserver 8001
 
-This will start the service at http://localhost:8000/ .
+This will start the service at http://localhost:8001/ .
 
 If you don't specify a port, the server will start on port 8000.
 We recommend getting in the habit of using port 8001 so you can


### PR DESCRIPTION
There was a spot that the port was listed as 8000, but should have been 8001.
