### PR TITLE
Added PostgreSQL to requirements

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -1,6 +1,6 @@
 From 0 to Shareabouts in about an hour
 ======================================
-Shareabouts requires python2.6 or greater.
+Shareabouts requires python2.6 or greater (and PostgreSQL 9.1 and development libraries by default to build).
 
 If you are converting from Shareabouts 1.0, note that
 we have switched platforms. See [the upgrade docs](UPGRADE.md).


### PR DESCRIPTION
Build fails by default if PostgreSQL isn't installed.

Error seen on a fresh-ish build of Ubuntu 12.04:

`
Error: pg_config executable not found.
Please add the directory containing pg_config to the PATH
or specify the full executable path with the option:
python setup.py build_ext --pg-config /path/to/pg_config build ...
or with the pg_config option in 'setup.cfg'.
`

and (if missing dev libraries)

`
Error: You need to install postgresql-server-dev-X.Y for building a server-side extension or libpq-dev for building a client-side application.
`
