### PR TITLE
Update doc/README.md file

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -46,6 +46,8 @@ Copy the file
 credentials for connecting to your development database.  This file will not be
 checked in to the repository.
 
+NOTE: If you are getting a "Peer authentication failed" error, you may need to set `HOST` in the DATABASES section to `localhost`. This is because Django attempts to connect to the database using UNIX sockets by default. More information on this error can be found [here](http://stackoverflow.com/questions/8167602/django-connection-to-postgresql-peer-authentication-failed/8232004#8232004)
+
 Then bootstrap the development database using the usual Django command:
 
     src/manage.py syncdb --migrate

--- a/doc/README.md
+++ b/doc/README.md
@@ -35,6 +35,9 @@ For PostGIS 2.0:
     
     createdb shareabouts_v2
     psql -U postgres -d shareabouts_v2 
+    \password postgres
+    Enter new password: <enter your password>
+    Enter it again: <enter your password again>
     CREATE EXTENSION postgis;    
     \q
 


### PR DESCRIPTION
 - Postgres users need to set up a password or else they will receive a
   'password authentication failed' message when starting the Django API
   server.
 - This password, as indicated in the README, should be added to the
   'DATABASE' section of their 'local_settings.py' file.