### PR TITLE
Need at least six 1.7.0 which includes `six.wraps`.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -59,7 +59,7 @@ django-cors-headers==0.12
 djangorestframework==2.3.12
 djangorestframework-csv==1.3.0
 git+https://github.com/mjumbewu/django-rest-framework-bulk.git@84a5d6c#egg=djangorestframework-bulk==0.1.3
-six>=1.4.1
+six>=1.7.0
 markdown  # For browsable API docs
 python-dateutil==2.2
 ujson==1.33


### PR DESCRIPTION
Otherwise Django produces a cryptic error:

  ...
    File "/usr/lib/python2.7/wsgiref/simple_server.py", line 33, in close
      self.status.split(' ',1)[0], self.bytes_sent
  AttributeError: 'NoneType' object has no attribute 'split'
