### PR TITLE
Use `migrate` now that `syncdb` is deprecated as of Django 1.7.

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -45,7 +45,7 @@ checked in to the repository.
 
 Then bootstrap the development database using the usual Django command:
 
-    src/manage.py syncdb --migrate
+    src/manage.py migrate
 
 
 Local setup


### PR DESCRIPTION
This will save people getting deprecation warnings when using Django 1.7 or errors on higher versions.