### PR TITLE
Fix Facebook social logins

### DIFF
--- a/src/project/settings.py
+++ b/src/project/settings.py
@@ -209,11 +209,11 @@ AUTH_USER_MODEL = 'sa_api_v2.User'
 SOCIAL_AUTH_USER_MODEL = 'sa_api_v2.User'
 SOCIAL_AUTH_PROTECTED_USER_FIELDS = ['email',]
 
-SOCIAL_AUTH_FACEBOOK_EXTRA_DATA = ['name', 'picture', 'bio']
+SOCIAL_AUTH_FACEBOOK_EXTRA_DATA = ['name', 'picture', 'about']
 SOCIAL_AUTH_TWITTER_EXTRA_DATA = ['name', 'description', 'profile_image_url']
 
 # Explicitly request the following extra things from facebook
-SOCIAL_AUTH_FACEBOOK_PROFILE_EXTRA_PARAMS = {'fields': 'id,name,picture.width(96).height(96),first_name,last_name,bio'}
+SOCIAL_AUTH_FACEBOOK_PROFILE_EXTRA_PARAMS = {'fields': 'id,name,picture.width(96).height(96),first_name,last_name,about'}
 
 SOCIAL_AUTH_LOGIN_ERROR_URL = 'remote-social-login-error'
 

--- a/src/sa_api_v2/serializers.py
+++ b/src/sa_api_v2/serializers.py
@@ -376,7 +376,7 @@ class FacebookUserDataStrategy (object):
         return user_info['name']
 
     def extract_bio(self, user_info):
-        return user_info['bio']
+        return user_info['about']
 
 
 class ShareaboutsUserDataStrategy (object):


### PR DESCRIPTION
The Facebook login feature on our Shareabouts fork recently stopped working. It sounds like this also might be a problem with the base project, given [this commit](https://github.com/openplans/shareabouts-api/commit/4c77f3fd78d6e0bb4cff886360aa76846dc64b50).

We discovered the problem is that the `bio` field is no longer a valid request parameter to the Facebook graph api, and should be replaced with the `about` field. Requesting the `bio` field will return a 400 error, and the social auth plugin will raise an `AuthCanceled` exception as a result.

See the `Deprecations in v2.8` section in the graph api changelog:
https://developers.facebook.com/docs/apps/changelog